### PR TITLE
refactor: abstract http client

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -41,8 +41,9 @@ func main() {
 
 	spotifySongParser := spotifySong.NewSpotifySongsParser()
 	songRepository := spotifySong.NewSpotifySongRepository(
-		httpClient,
-		spotifySong.SpotifySongRepositoryConfig{Host: *spotifyHost, AccessToken: *spotifyAccessToken},
+		*spotifyAccessToken,
+		*spotifyHost,
+		&httpSender,
 		&spotifySongParser,
 	)
 

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -33,8 +33,10 @@ func main() {
 	setlistFmParser := setlistfm.NewSetlistFMParser()
 	setlistFmParser.SetMinimumSongs(*minSongsPerSetlist)
 	setlistRepository := setlistfm.NewSetlistFMSetlistRepository(
-		&setlistfm.SetlistFMSetlistRepositoryConfig{Client: httpClient, Host: *setlistfmHost, ApiKey: *setlistfmApiKey},
+		*setlistfmHost,
+		*setlistfmApiKey,
 		&setlistFmParser,
+		&httpSender,
 	)
 
 	spotifySongParser := spotifySong.NewSpotifySongsParser()

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -6,6 +6,8 @@ import (
 	"net/http"
 	"os"
 
+	httpclient "festwrap/internal/http/client"
+	httpsender "festwrap/internal/http/sender"
 	"festwrap/internal/playlist"
 	spotifyPlaylist "festwrap/internal/playlist/spotify"
 	"festwrap/internal/setlist/setlistfm"
@@ -23,6 +25,8 @@ func main() {
 	flag.Parse()
 
 	httpClient := &http.Client{}
+	baseHttpClient := httpclient.NewBaseHTTPClient(httpClient)
+	httpSender := httpsender.NewBaseHTTPRequestSender(&baseHttpClient)
 
 	fmt.Printf("Adding latest setlist songs for %s into Spotify playlist with id %s \n", *artist, *playlistId)
 
@@ -40,7 +44,7 @@ func main() {
 		&spotifySongParser,
 	)
 
-	playlistRepository := spotifyPlaylist.NewSpotifyPlaylistRepository(*spotifyHost, httpClient, *spotifyAccessToken)
+	playlistRepository := spotifyPlaylist.NewSpotifyPlaylistRepository(*spotifyHost, &httpSender, *spotifyAccessToken)
 	playlistService := playlist.NewConcurrentPlaylistService(
 		&playlistRepository,
 		setlistRepository,

--- a/backend/internal/http/client/base_client.go
+++ b/backend/internal/http/client/base_client.go
@@ -1,0 +1,17 @@
+package httpclient
+
+import (
+	"net/http"
+)
+
+type BaseHTTPClient struct {
+	client *http.Client
+}
+
+func (c *BaseHTTPClient) Send(request *http.Request) (*http.Response, error) {
+	return c.client.Do(request)
+}
+
+func NewBaseHTTPClient(client *http.Client) BaseHTTPClient {
+	return BaseHTTPClient{client: client}
+}

--- a/backend/internal/http/client/client.go
+++ b/backend/internal/http/client/client.go
@@ -1,0 +1,9 @@
+package httpclient
+
+import (
+	"net/http"
+)
+
+type HTTPClient interface {
+	Send(request *http.Request) (*http.Response, error)
+}

--- a/backend/internal/http/client/fake_client.go
+++ b/backend/internal/http/client/fake_client.go
@@ -1,0 +1,37 @@
+package httpclient
+
+import (
+	"net/http"
+)
+
+type FakeHTTPClient struct {
+	requestArg *http.Request
+	response   *http.Response
+	err        error
+}
+
+func (c *FakeHTTPClient) Send(request *http.Request) (*http.Response, error) {
+	c.requestArg = request
+
+	if c.err != nil {
+		return nil, c.err
+	}
+
+	return c.response, nil
+}
+
+func (c *FakeHTTPClient) GetRequestArg() *http.Request {
+	return c.requestArg
+}
+
+func (c *FakeHTTPClient) SetResponse(response *http.Response) {
+	c.response = response
+}
+
+func (c *FakeHTTPClient) SetError(err error) {
+	c.err = err
+}
+
+func NewFakeHTTPClient() FakeHTTPClient {
+	return FakeHTTPClient{}
+}

--- a/backend/internal/http/sender/base_sender.go
+++ b/backend/internal/http/sender/base_sender.go
@@ -1,0 +1,60 @@
+package httpsender
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
+
+	httpclient "festwrap/internal/http/client"
+)
+
+type BaseHTTPRequestSender struct {
+	client httpclient.HTTPClient
+}
+
+func (c *BaseHTTPRequestSender) Send(options HTTPRequestOptions) (*[]byte, error) {
+	var body io.Reader = nil
+	if options.body != nil {
+		body = bytes.NewBuffer(options.body)
+	}
+
+	request, err := http.NewRequest(string(options.GetMethod()), options.GetUrl(), body)
+	addHeadersToRequest(options.GetHeaders(), request)
+	if err != nil {
+		return nil, fmt.Errorf("could not create HTTP request for options %v: %s", options, err.Error())
+	}
+
+	response, err := c.client.Send(request)
+	if err != nil {
+		return nil, fmt.Errorf("error sending HTTP request for options %v: %s", options, err.Error())
+	}
+
+	if response.StatusCode != options.GetExpectedStatusCode() {
+		errorMsg := fmt.Sprintf(
+			"request with options %v failed. Expected status code %d, found %d",
+			options,
+			options.GetExpectedStatusCode(),
+			response.StatusCode,
+		)
+		return nil, fmt.Errorf(errorMsg)
+	}
+
+	defer response.Body.Close()
+	responseBody, err := io.ReadAll(response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("error reading body for options %v: %s", options, err.Error())
+	}
+
+	return &responseBody, nil
+}
+
+func NewBaseHTTPRequestSender(client httpclient.HTTPClient) BaseHTTPRequestSender {
+	return BaseHTTPRequestSender{client: client}
+}
+
+func addHeadersToRequest(headers map[string]string, request *http.Request) {
+	for key, name := range headers {
+		request.Header.Add(key, name)
+	}
+}

--- a/backend/internal/http/sender/base_sender_test.go
+++ b/backend/internal/http/sender/base_sender_test.go
@@ -1,0 +1,188 @@
+package httpsender
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"testing"
+
+	httpclient "festwrap/internal/http/client"
+	"festwrap/internal/testtools"
+)
+
+func defaultRequestBody() []byte {
+	return []byte("{\"request\": \"some_request\"}")
+}
+
+func defaultOptions() HTTPRequestOptions {
+	options := NewHTTPRequestOptions("https://some_url", POST, 200)
+	options.SetBody(defaultRequestBody())
+	return options
+}
+
+func defaultResponseBody() []byte {
+	return []byte("{\"response\": \"some_response\"}")
+}
+
+func defaultResponse() *http.Response {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewBuffer(defaultResponseBody())),
+	}
+}
+
+func errorStatusResponse() *http.Response {
+	return &http.Response{Status: "500 Unexpected error", StatusCode: 500}
+}
+
+func errorBodyResponse() *http.Response {
+	return &http.Response{Status: "200 OK", StatusCode: 200, Body: testtools.NewErrorReader()}
+}
+
+func testSetup() (*httpclient.FakeHTTPClient, HTTPRequestSender, HTTPRequestOptions) {
+	client := httpclient.NewFakeHTTPClient()
+	client.SetResponse(defaultResponse())
+	options := defaultOptions()
+	sender := NewBaseHTTPRequestSender(&client)
+	return &client, &sender, options
+}
+
+func TestSendRequestHasProvidedMethod(t *testing.T) {
+	client, sender, options := testSetup()
+
+	_, err := sender.Send(options)
+
+	expected := client.GetRequestArg()
+	actual := string(options.GetMethod())
+	testtools.AssertEqual(t, actual, expected.Method)
+	testtools.AssertErrorIsNil(t, err)
+}
+
+func TestSendRequestHasProvidedUrl(t *testing.T) {
+	client, sender, options := testSetup()
+
+	_, err := sender.Send(options)
+
+	expected := client.GetRequestArg()
+	actual := options.GetUrl()
+	testtools.AssertEqual(t, actual, expected.URL.String())
+	testtools.AssertErrorIsNil(t, err)
+}
+
+func TestSendRequestHasProvidedBody(t *testing.T) {
+	client, sender, options := testSetup()
+
+	_, err := sender.Send(options)
+
+	expected := client.GetRequestArg()
+	actual := options.GetBody()
+	testtools.AssertEqual(t, string(actual), string(readBodyFromRequest(t, expected)))
+	testtools.AssertErrorIsNil(t, err)
+}
+
+func TestSendRequestDoesNotIncludeBodyIfNotProvided(t *testing.T) {
+	client, sender, options := testSetup()
+	options.SetBody(nil)
+
+	_, err := sender.Send(options)
+
+	expected := client.GetRequestArg()
+	testtools.AssertIsNil(t, expected.Body)
+	testtools.AssertErrorIsNil(t, err)
+}
+
+func TestSendRequestUsesHeaders(t *testing.T) {
+	client, sender, options := testSetup()
+	headers := map[string]string{
+		"Something":      "some_value",
+		"Something_else": "some_other_value",
+	}
+	options.SetHeaders(headers)
+
+	_, err := sender.Send(options)
+
+	expected := client.GetRequestArg()
+	assertHeadersMatch(t, headers, expected.Header)
+	testtools.AssertErrorIsNil(t, err)
+}
+
+func TestSendRequestUsesNoHeadersIfNotProvided(t *testing.T) {
+	client, sender, options := testSetup()
+
+	_, err := sender.Send(options)
+
+	expected := client.GetRequestArg()
+	if len(expected.Header) > 0 {
+		t.Errorf("Headers should be empty, found %v", expected.Header)
+	}
+	testtools.AssertErrorIsNil(t, err)
+}
+
+func TestSendRequestReturnsErrorOnErrorRequestOptions(t *testing.T) {
+	_, sender, options := testSetup()
+	options.SetUrl("https://bad url")
+
+	_, err := sender.Send(options)
+
+	testtools.AssertErrorNotNil(t, err)
+}
+
+func TestSendRequestReturnsErrorOnClientError(t *testing.T) {
+	client, sender, options := testSetup()
+	client.SetError(errors.New("Test client error"))
+
+	_, err := sender.Send(options)
+
+	testtools.AssertErrorNotNil(t, err)
+}
+
+func TestSendRequestReturnsErrorWhenStatusNotExpected(t *testing.T) {
+	client, sender, options := testSetup()
+	client.SetResponse(errorStatusResponse())
+
+	_, err := sender.Send(options)
+
+	testtools.AssertErrorNotNil(t, err)
+}
+
+func TestSendRequestReturnsErrorOnResponseBodyError(t *testing.T) {
+	client, sender, options := testSetup()
+	client.SetResponse(errorBodyResponse())
+
+	_, err := sender.Send(options)
+
+	testtools.AssertErrorNotNil(t, err)
+}
+
+func TestSendRequestReturnsResponseBody(t *testing.T) {
+	_, sender, options := testSetup()
+
+	body, err := sender.Send(options)
+
+	testtools.AssertEqual(t, string(*body), string(defaultResponseBody()))
+	testtools.AssertErrorIsNil(t, err)
+}
+
+func readBodyFromRequest(t *testing.T, request *http.Request) []byte {
+	requestBody, err := io.ReadAll(request.Body)
+	if err != nil {
+		t.Fatal("Could not read body from request")
+	}
+	defer request.Body.Close()
+	return requestBody
+}
+
+func assertHeadersMatch(t *testing.T, expected map[string]string, actual http.Header) {
+	for name, values := range actual {
+		if len(values) != 1 {
+			t.Errorf("Expected a single value for header %v, found %d", name, len(values))
+		}
+
+		if values[0] != expected[name] {
+			t.Errorf("Expected value %s for key %s, found %v", expected[name], name, values[0])
+		}
+	}
+}

--- a/backend/internal/http/sender/base_sender_test.go
+++ b/backend/internal/http/sender/base_sender_test.go
@@ -79,7 +79,7 @@ func TestSendRequestHasProvidedBody(t *testing.T) {
 
 	expected := client.GetRequestArg()
 	actual := options.GetBody()
-	testtools.AssertEqual(t, string(actual), string(readBodyFromRequest(t, expected)))
+	testtools.AssertEqual(t, actual, readBodyFromRequest(t, expected))
 	testtools.AssertErrorIsNil(t, err)
 }
 

--- a/backend/internal/http/sender/fake_sender.go
+++ b/backend/internal/http/sender/fake_sender.go
@@ -1,0 +1,33 @@
+package httpsender
+
+type FakeHTTPSender struct {
+	sendArgs HTTPRequestOptions
+	response *[]byte
+	err      error
+}
+
+func (s *FakeHTTPSender) GetSendArgs() HTTPRequestOptions {
+	return s.sendArgs
+}
+
+func (s *FakeHTTPSender) SetResponse(response *[]byte) {
+	s.response = response
+}
+
+func (s *FakeHTTPSender) SetError(err error) {
+	s.err = err
+}
+
+func (s *FakeHTTPSender) Send(options HTTPRequestOptions) (*[]byte, error) {
+	s.sendArgs = options
+
+	if s.err != nil {
+		return nil, s.err
+	} else {
+		return s.response, nil
+	}
+}
+
+func NewFakeHTTPSender() FakeHTTPSender {
+	return FakeHTTPSender{}
+}

--- a/backend/internal/http/sender/sender.go
+++ b/backend/internal/http/sender/sender.go
@@ -1,0 +1,56 @@
+package httpsender
+
+type HTTPRequestSender interface {
+	Send(options HTTPRequestOptions) (*[]byte, error)
+}
+
+type Method string
+
+const (
+	GET  Method = "GET"
+	POST Method = "POST"
+)
+
+type HTTPRequestOptions struct {
+	body               []byte
+	url                string
+	method             Method
+	headers            map[string]string
+	expectedStatusCode int
+}
+
+func (o *HTTPRequestOptions) GetBody() []byte {
+	return o.body
+}
+
+func (o *HTTPRequestOptions) GetUrl() string {
+	return o.url
+}
+
+func (o *HTTPRequestOptions) GetMethod() Method {
+	return o.method
+}
+
+func (o *HTTPRequestOptions) GetHeaders() map[string]string {
+	return o.headers
+}
+
+func (o *HTTPRequestOptions) GetExpectedStatusCode() int {
+	return o.expectedStatusCode
+}
+
+func (o *HTTPRequestOptions) SetUrl(url string) {
+	o.url = url
+}
+
+func (o *HTTPRequestOptions) SetBody(body []byte) {
+	o.body = body
+}
+
+func (o *HTTPRequestOptions) SetHeaders(headers map[string]string) {
+	o.headers = headers
+}
+
+func NewHTTPRequestOptions(url string, method Method, expectedStatusCode int) HTTPRequestOptions {
+	return HTTPRequestOptions{url: url, body: nil, method: method, expectedStatusCode: expectedStatusCode}
+}

--- a/backend/internal/playlist/concurrent_playlist_service_test.go
+++ b/backend/internal/playlist/concurrent_playlist_service_test.go
@@ -134,7 +134,7 @@ func TestAddSetlistSongRepositoryCalledWithSetlistSongs(t *testing.T) {
 	actual := songRepository.GetGetSongArgs()
 	expected := defaultGetSongArgs()
 	testtools.AssertErrorIsNil(t, err)
-	if !testtools.HaveSameElements[song.GetSongArgs](actual, expected) {
+	if !testtools.HaveSameElements(actual, expected) {
 		t.Errorf("Expected called songs %v, found %v", expected, actual)
 	}
 }

--- a/backend/internal/playlist/concurrent_playlist_service_test.go
+++ b/backend/internal/playlist/concurrent_playlist_service_test.go
@@ -2,7 +2,6 @@ package playlist
 
 import (
 	"errors"
-	"reflect"
 	"testing"
 
 	"festwrap/internal/setlist"
@@ -149,9 +148,7 @@ func TestAddSetlistAddsSongsFetched(t *testing.T) {
 	actual := playlistRepository.GetAddSongArgs()
 	expected := defaultAddSongsArgs()
 	testtools.AssertErrorIsNil(t, err)
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("Expected added songs call to be %v, found %v", expected, actual)
-	}
+	testtools.AssertEqual(t, actual, expected)
 }
 
 func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
@@ -164,9 +161,7 @@ func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
 	actual := playlistRepository.GetAddSongArgs()
 	expected := addSongsArgsWithErrors()
 	testtools.AssertErrorIsNil(t, err)
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("Expected added songs call to be %v, found %v", expected, actual)
-	}
+	testtools.AssertEqual(t, actual, expected)
 }
 
 func TestAddSetlistSetlistRaisesErrorIfSetlistEmpty(t *testing.T) {

--- a/backend/internal/playlist/concurrent_playlist_service_test.go
+++ b/backend/internal/playlist/concurrent_playlist_service_test.go
@@ -10,63 +10,57 @@ import (
 	"festwrap/internal/testtools"
 )
 
-func PlaylistId() string {
+func defaultPlaylistId() string {
 	return "myPlaylist"
 }
 
-func Artist() string {
+func defaultArtist() string {
 	return "myArtist"
 }
 
-func Songs() []interface{} {
+func defaultSongs() []interface{} {
 	return []interface{}{
 		song.NewSong("some_uri"),
 		song.NewSong("another_uri"),
 	}
 }
 
-func SongsWithErrors() []interface{} {
+func songsWithErrors() []interface{} {
 	return []interface{}{
 		errors.New("Some error"),
 		song.NewSong("another_uri"),
 	}
 }
 
-func ErrorSongs() []interface{} {
+func errorSongs() []interface{} {
 	return []interface{}{
 		errors.New("Some error"),
 		errors.New("Some other error"),
 	}
 }
 
-func Setlist() setlist.Setlist {
+func defaultSetlist() setlist.Setlist {
 	songs := []setlist.Song{
 		setlist.NewSong("My song"),
 		setlist.NewSong("My other song"),
 	}
-	return setlist.NewSetlist(Artist(), songs)
+	return setlist.NewSetlist(defaultArtist(), songs)
 }
 
-func EmptySetlist() setlist.Setlist {
-	return setlist.NewSetlist(Artist(), []setlist.Song{})
+func emptySetlist() setlist.Setlist {
+	return setlist.NewSetlist(defaultArtist(), []setlist.Song{})
 }
 
-func DefaultGetSongArgs() []song.GetSongArgs {
+func defaultGetSongArgs() []song.GetSongArgs {
 	return []song.GetSongArgs{
-		song.GetSongArgs{Artist: Artist(), Title: "My song"},
-		song.GetSongArgs{Artist: Artist(), Title: "My other song"},
+		{Artist: defaultArtist(), Title: "My song"},
+		{Artist: defaultArtist(), Title: "My other song"},
 	}
 }
 
-func GetSongArgsWithErrors() []song.GetSongArgs {
-	return []song.GetSongArgs{
-		song.GetSongArgs{Artist: Artist(), Title: "My other song"},
-	}
-}
-
-func DefaultAddSongsArgs() AddSongsArgs {
+func defaultAddSongsArgs() AddSongsArgs {
 	return AddSongsArgs{
-		PlaylistId: PlaylistId(),
+		PlaylistId: defaultPlaylistId(),
 		Songs: []song.Song{
 			song.NewSong("some_uri"),
 			song.NewSong("another_uri"),
@@ -74,42 +68,42 @@ func DefaultAddSongsArgs() AddSongsArgs {
 	}
 }
 
-func AddSongsArgsWithErrors() AddSongsArgs {
+func addSongsArgsWithErrors() AddSongsArgs {
 	return AddSongsArgs{
-		PlaylistId: PlaylistId(),
+		PlaylistId: defaultPlaylistId(),
 		Songs: []song.Song{
 			song.NewSong("another_uri"),
 		},
 	}
 }
 
-func NewFakeSetlistRepository() setlist.FakeSetlistRepository {
+func newFakeSetlistRepository() setlist.FakeSetlistRepository {
 	repository := setlist.NewFakeSetlistRepository()
-	returnSetlist := Setlist()
+	returnSetlist := defaultSetlist()
 	repository.SetReturnValue(&returnSetlist)
 	return repository
 }
 
-func NewFakeSongRepository() song.FakeSongRepository {
+func newFakeSongRepository() song.FakeSongRepository {
 	repository := song.NewFakeSongRepository()
-	repository.SetSongs(Songs())
+	repository.SetSongs(defaultSongs())
 	return repository
 }
 
 func testSetup() (FakePlaylistRepository, setlist.FakeSetlistRepository, song.FakeSongRepository) {
 	playlistRepository := NewFakePlaylistRepository()
-	setlistRepository := NewFakeSetlistRepository()
-	songRepository := NewFakeSongRepository()
+	setlistRepository := newFakeSetlistRepository()
+	songRepository := newFakeSongRepository()
 	return playlistRepository, setlistRepository, songRepository
 }
 
 func TestAddSetlistSetlistRepositoryCalledWithArtist(t *testing.T) {
-	expected := Artist()
+	expected := defaultArtist()
 	playlistRepository, setlistRepository, songRepository := testSetup()
 
 	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
 
-	err := service.AddSetlist(PlaylistId(), expected)
+	err := service.AddSetlist(defaultPlaylistId(), expected)
 
 	actual := setlistRepository.GetCalledArtist()
 	testtools.AssertErrorIsNil(t, err)
@@ -124,7 +118,7 @@ func TestAddSetlistReturnsErrorOnSetlistRepositoryError(t *testing.T) {
 	setlistRepository.SetError(returnError)
 	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
 
-	err := service.AddSetlist(PlaylistId(), Artist())
+	err := service.AddSetlist(defaultPlaylistId(), defaultArtist())
 
 	if err != returnError {
 		t.Errorf("Setlist repository should have returned an error but it did not")
@@ -135,10 +129,10 @@ func TestAddSetlistSongRepositoryCalledWithSetlistSongs(t *testing.T) {
 	playlistRepository, setlistRepository, songRepository := testSetup()
 	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
 
-	err := service.AddSetlist(PlaylistId(), Artist())
+	err := service.AddSetlist(defaultPlaylistId(), defaultArtist())
 
 	actual := songRepository.GetGetSongArgs()
-	expected := DefaultGetSongArgs()
+	expected := defaultGetSongArgs()
 	testtools.AssertErrorIsNil(t, err)
 	if !testtools.HaveSameElements[song.GetSongArgs](actual, expected) {
 		t.Errorf("Expected called songs %v, found %v", expected, actual)
@@ -147,13 +141,13 @@ func TestAddSetlistSongRepositoryCalledWithSetlistSongs(t *testing.T) {
 
 func TestAddSetlistAddsSongsFetched(t *testing.T) {
 	playlistRepository, setlistRepository, songRepository := testSetup()
-	songRepository.SetSongs(Songs())
+	songRepository.SetSongs(defaultSongs())
 	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
 
-	err := service.AddSetlist(PlaylistId(), Artist())
+	err := service.AddSetlist(defaultPlaylistId(), defaultArtist())
 
 	actual := playlistRepository.GetAddSongArgs()
-	expected := DefaultAddSongsArgs()
+	expected := defaultAddSongsArgs()
 	testtools.AssertErrorIsNil(t, err)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected added songs call to be %v, found %v", expected, actual)
@@ -162,13 +156,13 @@ func TestAddSetlistAddsSongsFetched(t *testing.T) {
 
 func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
 	playlistRepository, setlistRepository, songRepository := testSetup()
-	songRepository.SetSongs(SongsWithErrors())
+	songRepository.SetSongs(songsWithErrors())
 	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
 
-	err := service.AddSetlist("myPlaylist", Artist())
+	err := service.AddSetlist("myPlaylist", defaultArtist())
 
 	actual := playlistRepository.GetAddSongArgs()
-	expected := AddSongsArgsWithErrors()
+	expected := addSongsArgsWithErrors()
 	testtools.AssertErrorIsNil(t, err)
 	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected added songs call to be %v, found %v", expected, actual)
@@ -177,21 +171,21 @@ func TestAddSetlistAddsOnlySongsFetchedWithoutError(t *testing.T) {
 
 func TestAddSetlistSetlistRaisesErrorIfSetlistEmpty(t *testing.T) {
 	playlistRepository, setlistRepository, songRepository := testSetup()
-	songRepository.SetSongs(ErrorSongs())
+	songRepository.SetSongs(errorSongs())
 	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
 
-	err := service.AddSetlist(PlaylistId(), Artist())
+	err := service.AddSetlist(defaultPlaylistId(), defaultArtist())
 
 	testtools.AssertErrorNotNil(t, err)
 }
 
 func TestAddSetlistSetlistRaisesErrorIfNoSongsFound(t *testing.T) {
 	playlistRepository, setlistRepository, songRepository := testSetup()
-	setlist := EmptySetlist()
+	setlist := emptySetlist()
 	setlistRepository.SetReturnValue(&setlist)
 	service := NewConcurrentPlaylistService(&playlistRepository, &setlistRepository, &songRepository)
 
-	err := service.AddSetlist(PlaylistId(), Artist())
+	err := service.AddSetlist(defaultPlaylistId(), defaultArtist())
 
 	testtools.AssertErrorNotNil(t, err)
 }

--- a/backend/internal/setlist/setlistfm/setlistfm_parser_test.go
+++ b/backend/internal/setlist/setlistfm/setlistfm_parser_test.go
@@ -56,9 +56,7 @@ func TestSetlistRetrieved(t *testing.T) {
 	actual := parseResponse(t, parser)
 
 	expected := expectedSetlist(t)
-	if !reflect.DeepEqual(actual, expected) {
-		t.Errorf("Found %v, expected %v", actual, expected)
-	}
+	testtools.AssertEqual(t, actual, expected)
 }
 
 func TestNoSetlistRetrievedWhenMinSongsNotReached(t *testing.T) {

--- a/backend/internal/setlist/setlistfm/setlistfm_setlist_repository.go
+++ b/backend/internal/setlist/setlistfm/setlistfm_setlist_repository.go
@@ -2,86 +2,62 @@ package setlistfm
 
 import (
 	"fmt"
-	"io"
-	"net/http"
 	"net/url"
 
+	httpsender "festwrap/internal/http/sender"
 	"festwrap/internal/setlist"
 	"festwrap/internal/setlist/errors"
 )
 
-type SetlistFMSetlistRepositoryConfig struct {
-	Client *http.Client
-	Host   string
-	ApiKey string
-}
-
 type SetlistFMRepository struct {
-	config *SetlistFMSetlistRepositoryConfig
-	parser setlist.SetlistParser
+	host       string
+	apiKey     string
+	parser     setlist.SetlistParser
+	httpSender httpsender.HTTPRequestSender
 }
 
-func (s *SetlistFMRepository) GetSetlist(artist string) (*setlist.Setlist, error) {
+func (r *SetlistFMRepository) GetSetlist(artist string) (*setlist.Setlist, error) {
 
-	request, err := s.createSetlistRequest(artist)
+	httpOptions := r.createSetlistHttpOptions(artist)
+	responseBody, err := r.httpSender.Send(httpOptions)
 	if err != nil {
-		errorMsg := fmt.Sprintf("Cannot create request for %s: %s", s.config.Host, err.Error())
-		return nil, errors.NewCannotRetrieveSetlistError(errorMsg)
+		return nil, errors.NewCannotRetrieveSetlistError(err.Error())
 	}
 
-	response, err := s.config.Client.Do(request)
+	setlist, err := r.parser.Parse(*responseBody)
 	if err != nil {
-		errorMsg := fmt.Sprintf(
-			"Cannot retrieve response for %s: %s", s.config.Host, err.Error(),
-		)
-		return nil, errors.NewCannotRetrieveSetlistError(errorMsg)
-	}
-	defer response.Body.Close()
-
-	if response.StatusCode != http.StatusOK {
-		errorMsg := fmt.Sprintf(
-			"Setlistfm returned %d when trying to retrieve setlists for %s", response.StatusCode, artist,
-		)
-		return nil, errors.NewCannotRetrieveSetlistError(errorMsg)
-	}
-
-	body, err := io.ReadAll(response.Body)
-	if err != nil {
-		errorMsg := fmt.Sprintf("Error reading response %s: ", err.Error())
-		return nil, errors.NewCannotRetrieveSetlistError(errorMsg)
-	}
-
-	setlist, err := s.parser.Parse(body)
-	if err != nil {
-		return nil, err
+		return nil, errors.NewCannotRetrieveSetlistError(err.Error())
 	}
 	if setlist == nil {
 		// TODO: if no valid setlist found, we should check for the next page
 		// TODO: probable a good idea to move the min songs filter to repository and keep parser simpler
 		errorMsg := fmt.Sprintf("Could not find setlist for artist %s", artist)
-		errors.NewCannotRetrieveSetlistError(errorMsg)
+		return nil, errors.NewCannotRetrieveSetlistError(errorMsg)
 	}
 
 	return setlist, nil
 }
 
-func (s *SetlistFMRepository) createSetlistRequest(artist string) (*http.Request, error) {
-	request, err := http.NewRequest("GET", s.getSetlistFullUrl(artist), nil)
-	if err != nil {
-		return nil, err
-	}
-	request.Header.Add("x-api-key", s.config.ApiKey)
-	request.Header.Add("Accept", "application/json")
-	return request, nil
+func (r *SetlistFMRepository) createSetlistHttpOptions(artist string) httpsender.HTTPRequestOptions {
+	httpOptions := httpsender.NewHTTPRequestOptions(r.getSetlistFullUrl(artist), httpsender.GET, 200)
+	httpOptions.SetHeaders(
+		map[string]string{
+			"x-api-key": r.apiKey,
+			"Accept":    "application/json",
+		},
+	)
+	return httpOptions
 }
 
-func (s *SetlistFMRepository) getSetlistFullUrl(artist string) string {
+func (r *SetlistFMRepository) getSetlistFullUrl(artist string) string {
 	queryParams := url.Values{}
 	queryParams.Set("artistName", artist)
 	setlistPath := "rest/1.0/search/setlists"
-	return fmt.Sprintf("https://%s/%s?%s", s.config.Host, setlistPath, queryParams.Encode())
+	return fmt.Sprintf("https://%s/%s?%s", r.host, setlistPath, queryParams.Encode())
 }
 
-func NewSetlistFMSetlistRepository(config *SetlistFMSetlistRepositoryConfig, parser setlist.SetlistParser) *SetlistFMRepository {
-	return &SetlistFMRepository{config: config, parser: parser}
+func NewSetlistFMSetlistRepository(
+	host string, apiKey string, parser setlist.SetlistParser, httpSender httpsender.HTTPRequestSender,
+) *SetlistFMRepository {
+	return &SetlistFMRepository{host: host, apiKey: apiKey, parser: parser, httpSender: httpSender}
 }

--- a/backend/internal/song/spotify/spotify_songs_parser_test.go
+++ b/backend/internal/song/spotify/spotify_songs_parser_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"slices"
 	"testing"
 
 	"festwrap/internal/song"
@@ -52,9 +51,7 @@ func TestSongRetrieved(t *testing.T) {
 	result := parseResponse(t, parser)
 
 	expected := expectedSongs(t)
-	if !slices.Equal(*result, *expected) {
-		t.Errorf("Found %v, expected %v", result, expected)
-	}
+	testtools.AssertEqual(t, *result, *expected)
 }
 
 func TestReturnsErrorWhenResponseIsNotJson(t *testing.T) {

--- a/backend/internal/testtools/check.go
+++ b/backend/internal/testtools/check.go
@@ -8,6 +8,12 @@ func HaveSameElements[T comparable](set1 []T, set2 []T) bool {
 	return areCountsEqual(c1, c2)
 }
 
+func AssertIsNil(t *testing.T, value interface{}) {
+	if value != nil {
+		t.Errorf("Value should be nil, but found %v", value)
+	}
+}
+
 func AssertErrorIsNil(t *testing.T, err error) {
 	if err != nil {
 		t.Errorf("Error should be nil, but found %v", err)
@@ -17,6 +23,12 @@ func AssertErrorIsNil(t *testing.T, err error) {
 func AssertErrorNotNil(t *testing.T, err error) {
 	if err == nil {
 		t.Errorf("Expected error, found nil")
+	}
+}
+
+func AssertEqual(t *testing.T, actual interface{}, expected interface{}) {
+	if actual != expected {
+		t.Errorf("Expected %v, found %v", expected, actual)
 	}
 }
 

--- a/backend/internal/testtools/check.go
+++ b/backend/internal/testtools/check.go
@@ -1,6 +1,9 @@
 package testtools
 
-import "testing"
+import (
+	"reflect"
+	"testing"
+)
 
 func HaveSameElements[T comparable](set1 []T, set2 []T) bool {
 	c1 := valueCounts(set1)
@@ -27,7 +30,7 @@ func AssertErrorNotNil(t *testing.T, err error) {
 }
 
 func AssertEqual(t *testing.T, actual interface{}, expected interface{}) {
-	if actual != expected {
+	if !reflect.DeepEqual(actual, expected) {
 		t.Errorf("Expected %v, found %v", expected, actual)
 	}
 }

--- a/backend/internal/testtools/io.go
+++ b/backend/internal/testtools/io.go
@@ -1,6 +1,7 @@
 package testtools
 
 import (
+	"errors"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -13,4 +14,18 @@ func GetParentDir(t *testing.T) string {
 		t.Fatal("Could not find the file directory of the caller")
 	}
 	return filepath.Dir(filepath.Dir(filename))
+}
+
+type ErrorReader struct{}
+
+func (ErrorReader) Read(p []byte) (n int, err error) {
+	return 0, errors.New("test error")
+}
+
+func (ErrorReader) Close() error {
+	return nil
+}
+
+func NewErrorReader() ErrorReader {
+	return ErrorReader{}
 }


### PR DESCRIPTION
# Description

Abstracts the sending of HTTP requests so we can reuse a big fraction of the code in the repositories but also facilitating repository testing (we will do this in incoming PRs).

Following the [scout rule](https://matheus.ro/2017/12/11/clean-code-boy-scout-rule/), we also improved consistency and good practises while implementing this (e.g. removing warning, standardizing auxiliar functions in test).

# Test

## Obtaining the access token

We first obtain a token as described in the [frontend](https://github.com/DanielMoraDC/festwrap/tree/main/frontend). Open the frontend app by typing this in the root of the project:

```
cd frontend
make run-app
```

Then go to [localhost](http://localhost:3000) and login in Spotify:

<img width="933" alt="Captura de pantalla 2024-07-31 a les 9 49 14" src="https://github.com/user-attachments/assets/270399d0-4e4a-49bf-8fbd-ac52bf72de51">

Once logged, you will be able to copy the token for the next step:

<img width="933" alt="Captura de pantalla 2024-07-31 a les 9 49 18" src="https://github.com/user-attachments/assets/31184af2-d316-4db8-9f8d-4db21ec33444">


## Run the main script

Then, we can run the main script to check it works:

```
cd backend
go \
    run cmd/main.go \
    --spotify-token <spotify_token> \
    --setlistfm-key <setlistfm_key> \
    --artist Brutus \
    --playlist-id <playlist_id>
```

You should use the Spotify token from the previous step. For the other values, see the [README](backend/README.md).

You should see a set of songs added to your playlist after running the script above:

<img width="972" alt="Captura de pantalla 2024-07-31 a les 9 52 31" src="https://github.com/user-attachments/assets/03b396a2-2dcc-4879-a94b-6ebb7bdf02ac">
