### PR TITLE
chore: test spotify song repo

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -39,12 +39,10 @@ func main() {
 		&httpSender,
 	)
 
-	spotifySongParser := spotifySong.NewSpotifySongsParser()
 	songRepository := spotifySong.NewSpotifySongRepository(
 		*spotifyAccessToken,
 		*spotifyHost,
 		&httpSender,
-		&spotifySongParser,
 	)
 
 	playlistRepository := spotifyPlaylist.NewSpotifyPlaylistRepository(*spotifyHost, &httpSender, *spotifyAccessToken)

--- a/backend/internal/song/songs_parser.go
+++ b/backend/internal/song/songs_parser.go
@@ -1,5 +1,0 @@
-package song
-
-type SongsParser interface {
-	Parse(songs []byte) (*[]Song, error)
-}

--- a/backend/internal/song/spotify/fake_songs_parser.go
+++ b/backend/internal/song/spotify/fake_songs_parser.go
@@ -1,0 +1,31 @@
+package spotify
+
+import (
+	"festwrap/internal/song"
+)
+
+type FakeSongsParser struct {
+	response  []song.Song
+	err       error
+	parseArgs []byte
+}
+
+func (s *FakeSongsParser) SetResponse(response []song.Song) {
+	s.response = response
+}
+
+func (s *FakeSongsParser) SetError(err error) {
+	s.err = err
+}
+
+func (s *FakeSongsParser) GetParseArgs() []byte {
+	return s.parseArgs
+}
+
+func (s *FakeSongsParser) Parse(setlist []byte) ([]song.Song, error) {
+	s.parseArgs = setlist
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.response, nil
+}

--- a/backend/internal/song/spotify/songs_parser.go
+++ b/backend/internal/song/spotify/songs_parser.go
@@ -1,0 +1,7 @@
+package spotify
+
+import "festwrap/internal/song"
+
+type SongsParser interface {
+	Parse(songs []byte) ([]song.Song, error)
+}

--- a/backend/internal/song/spotify/spotify_song_repository.go
+++ b/backend/internal/song/spotify/spotify_song_repository.go
@@ -13,7 +13,7 @@ type SpotifySongRepository struct {
 	accessToken string
 	host        string
 	httpSender  httpsender.HTTPRequestSender
-	parser      *SpotifySongsParser
+	parser      SongsParser
 }
 
 func (r *SpotifySongRepository) GetSong(artist string, title string) (*song.Song, error) {
@@ -28,7 +28,7 @@ func (r *SpotifySongRepository) GetSong(artist string, title string) (*song.Song
 		return nil, errors.NewCannotRetrieveSongError(err.Error())
 	}
 
-	allSongs := *songs
+	allSongs := songs
 	if len(allSongs) == 0 {
 		errorMsg := fmt.Sprintf("No songs found for song %s (%s)", title, artist)
 		return nil, errors.NewCannotRetrieveSongError(errorMsg)
@@ -36,6 +36,10 @@ func (r *SpotifySongRepository) GetSong(artist string, title string) (*song.Song
 
 	// We assume the first result is the most trusted one
 	return &allSongs[0], nil
+}
+
+func (r *SpotifySongRepository) SetParser(parser SongsParser) {
+	r.parser = parser
 }
 
 func (r *SpotifySongRepository) createSongHttpOptions(artist string, title string) httpsender.HTTPRequestOptions {
@@ -58,7 +62,7 @@ func NewSpotifySongRepository(
 	accessToken string,
 	host string,
 	httpSender httpsender.HTTPRequestSender,
-	parser *SpotifySongsParser,
 ) *SpotifySongRepository {
-	return &SpotifySongRepository{accessToken: accessToken, host: host, httpSender: httpSender, parser: parser}
+	return &SpotifySongRepository{
+		accessToken: accessToken, host: host, httpSender: httpSender, parser: &SpotifySongsParser{}}
 }

--- a/backend/internal/song/spotify/spotify_song_repository_test.go
+++ b/backend/internal/song/spotify/spotify_song_repository_test.go
@@ -1,0 +1,115 @@
+package spotify
+
+import (
+	"errors"
+	httpsender "festwrap/internal/http/sender"
+	"festwrap/internal/song"
+	"festwrap/internal/testtools"
+	"testing"
+)
+
+func defaultArtist() string {
+	return "Movements"
+}
+
+func defaultTitle() string {
+	return "Daylily"
+}
+
+func expectedHttpOptions() httpsender.HTTPRequestOptions {
+	url := "https://spotify.com/v1/search?q=artist%3AMovements+track%3ADaylily&type=track"
+	options := httpsender.NewHTTPRequestOptions(url, httpsender.GET, 200)
+	options.SetHeaders(
+		map[string]string{"Authorization": "Bearer some_token"},
+	)
+	return options
+}
+
+func defaultSenderResponse() *[]byte {
+	response := []byte("some body")
+	return &response
+}
+
+func defaultParsedSongs() []song.Song {
+	return []song.Song{song.NewSong("some uri"), song.NewSong("another uri")}
+}
+
+func defaultSender() *httpsender.FakeHTTPSender {
+	sender := &httpsender.FakeHTTPSender{}
+	sender.SetResponse(defaultSenderResponse())
+	return sender
+}
+
+func defaultParser() *FakeSongsParser {
+	parser := &FakeSongsParser{}
+	parser.SetResponse(defaultParsedSongs())
+	return parser
+}
+
+func spotifySongRepository(sender httpsender.HTTPRequestSender) SpotifySongRepository {
+	repository := NewSpotifySongRepository("some_token", "spotify.com", sender)
+	repository.SetParser(defaultParser())
+	return *repository
+}
+
+func TestGetSongSendsRequestWithProperOptions(t *testing.T) {
+	sender := defaultSender()
+	repository := spotifySongRepository(sender)
+
+	_, err := repository.GetSong(defaultArtist(), defaultTitle())
+
+	testtools.AssertErrorIsNil(t, err)
+	testtools.AssertEqual(t, sender.GetSendArgs(), expectedHttpOptions())
+}
+
+func TestGetSongReturnsErrorOnSendError(t *testing.T) {
+	sender := &httpsender.FakeHTTPSender{}
+	sender.SetError(errors.New("test error"))
+	repository := spotifySongRepository(sender)
+
+	_, err := repository.GetSong(defaultArtist(), defaultTitle())
+
+	testtools.AssertErrorIsNotNil(t, err)
+}
+
+func TestGetSongCallsParserWithSendResponseBody(t *testing.T) {
+	repository := spotifySongRepository(defaultSender())
+	parser := defaultParser()
+	repository.SetParser(parser)
+
+	_, err := repository.GetSong(defaultArtist(), defaultTitle())
+
+	testtools.AssertErrorIsNil(t, err)
+	testtools.AssertEqual(t, parser.GetParseArgs(), *defaultSenderResponse())
+}
+
+func TestGetSongReturnsErrorOnResponseBodyParseError(t *testing.T) {
+	repository := spotifySongRepository(defaultSender())
+	parser := &FakeSongsParser{}
+	parser.SetError(errors.New("test error"))
+	repository.SetParser(parser)
+
+	_, err := repository.GetSong(defaultArtist(), defaultTitle())
+
+	testtools.AssertErrorIsNotNil(t, err)
+}
+
+func TestGetSongReturnsErrorIfNoSongsParsed(t *testing.T) {
+	repository := spotifySongRepository(defaultSender())
+	parser := &FakeSongsParser{}
+	parser.SetResponse([]song.Song{})
+	repository.SetParser(parser)
+
+	_, err := repository.GetSong(defaultArtist(), defaultTitle())
+
+	testtools.AssertErrorIsNotNil(t, err)
+}
+
+func TestGetSongReturnsFirstSongParsed(t *testing.T) {
+	repository := spotifySongRepository(defaultSender())
+
+	song, err := repository.GetSong(defaultArtist(), defaultTitle())
+
+	testtools.AssertErrorIsNil(t, err)
+	testtools.AssertEqual(t, *song, defaultParsedSongs()[0])
+}

--- a/backend/internal/song/spotify/spotify_songs_parser.go
+++ b/backend/internal/song/spotify/spotify_songs_parser.go
@@ -9,7 +9,7 @@ import (
 
 type SpotifySongsParser struct{}
 
-func (s *SpotifySongsParser) Parse(setlist []byte) (*[]song.Song, error) {
+func (s *SpotifySongsParser) Parse(setlist []byte) ([]song.Song, error) {
 	var parsedResponse SpotifyResponse
 	err := json.Unmarshal(setlist, &parsedResponse)
 	if err != nil {
@@ -20,7 +20,7 @@ func (s *SpotifySongsParser) Parse(setlist []byte) (*[]song.Song, error) {
 	for _, currentSong := range parsedResponse.Tracks.Songs {
 		result = append(result, song.NewSong(currentSong.Uri))
 	}
-	return &result, nil
+	return result, nil
 }
 
 func NewSpotifySongsParser() SpotifySongsParser {

--- a/backend/internal/song/spotify/spotify_songs_parser_test.go
+++ b/backend/internal/song/spotify/spotify_songs_parser_test.go
@@ -36,7 +36,7 @@ func expectedSongs(t *testing.T) *[]song.Song {
 	return &songs
 }
 
-func parseResponse(t *testing.T, parser SpotifySongsParser) *[]song.Song {
+func parseResponse(t *testing.T, parser SpotifySongsParser) []song.Song {
 	response := loadResponse(t)
 	result, err := parser.Parse(response)
 	if err != nil {
@@ -51,7 +51,7 @@ func TestSongRetrieved(t *testing.T) {
 	result := parseResponse(t, parser)
 
 	expected := expectedSongs(t)
-	testtools.AssertEqual(t, *result, *expected)
+	testtools.AssertEqual(t, result, *expected)
 }
 
 func TestReturnsErrorWhenResponseIsNotJson(t *testing.T) {

--- a/backend/internal/song/spotify/spotify_songs_parser_test.go
+++ b/backend/internal/song/spotify/spotify_songs_parser_test.go
@@ -36,7 +36,7 @@ func expectedSongs(t *testing.T) *[]song.Song {
 	return &songs
 }
 
-func parseResponse(t *testing.T, parser SpotifySongsParser) []song.Song {
+func parsedResponse(t *testing.T, parser SpotifySongsParser) []song.Song {
 	response := loadResponse(t)
 	result, err := parser.Parse(response)
 	if err != nil {
@@ -48,7 +48,7 @@ func parseResponse(t *testing.T, parser SpotifySongsParser) []song.Song {
 func TestSongRetrieved(t *testing.T) {
 	parser := NewSpotifySongsParser()
 
-	result := parseResponse(t, parser)
+	result := parsedResponse(t, parser)
 
 	expected := expectedSongs(t)
 	testtools.AssertEqual(t, result, *expected)


### PR DESCRIPTION
# Description

Adds tests to the Spotify song repository.

Added some additonal minor changes:
- Move interface to more suited submodule.
- Return value instead of pointer in song parser.
- Use production parser by default, enabling to change it with a setter to ease testing.