### PR TITLE
fix: Use at least one songs in setlists

### DIFF
--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -34,6 +34,7 @@ func main() {
 		*setlistfmApiKey,
 		&httpSender,
 	)
+	setlistRepository.SetParser(&setlistFmParser)
 
 	songRepository := spotifySong.NewSpotifySongRepository(
 		*spotifyAccessToken,

--- a/backend/internal/setlist/setlistfm/setlistfm_setlist_repository.go
+++ b/backend/internal/setlist/setlistfm/setlistfm_setlist_repository.go
@@ -61,5 +61,6 @@ func (r *SetlistFMRepository) getSetlistFullUrl(artist string) string {
 }
 
 func NewSetlistFMSetlistRepository(apiKey string, httpSender httpsender.HTTPRequestSender) *SetlistFMRepository {
-	return &SetlistFMRepository{host: "api.setlist.fm", apiKey: apiKey, parser: &SetlistFMParser{}, httpSender: httpSender}
+	parser := NewSetlistFMParser()
+	return &SetlistFMRepository{host: "api.setlist.fm", apiKey: apiKey, parser: &parser, httpSender: httpSender}
 }


### PR DESCRIPTION
# Description

In a past refactor, we enabled the default minimum songs for a valid setlist to be. As a consequence, we were always using the first setlist found, even if it was empty.

These changes consider a valid setlist to at least have one song and also fix the main backend script to actually use the provided minimum amount of songs.