### PR TITLE
docs: remove Trello link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,6 @@ This repository is serving two purposes:
 
 We are relying on Spotify for storing the playlists and Setlistfm for retrieving the top songs from each artist, though we can support other services in the future.
 
-For this initial version I have allowed some technical debt to slip in (e.g. code duplication), but I plan to remove it in incoming iterations. I keep a small backlog of tasks in this [board](https://trello.com/b/Iv1rrKwE/festwrap).
-
 # Local development
 
 We use pre-commit for static code analysis. Make sure hooks are installed (i.e. `brew install pre-commit` in MacOS) before contributing:


### PR DESCRIPTION
# Description

We are moving from Trello to private JIRA cloud, removing the link to old Trello.