### PR TITLE
refactor: move constructors after definition

### DIFF
--- a/backend/internal/artist/artist.go
+++ b/backend/internal/artist/artist.go
@@ -5,14 +5,14 @@ type Artist struct {
 	imageUri string
 }
 
-func (a *Artist) SetImageUri(imageUri string) {
-	a.imageUri = imageUri
-}
-
 func NewArtist(name string) Artist {
 	return Artist{name: name}
 }
 
 func NewArtistWithImageUri(name string, imageUri string) Artist {
 	return Artist{name: name, imageUri: imageUri}
+}
+
+func (a *Artist) SetImageUri(imageUri string) {
+	a.imageUri = imageUri
 }

--- a/backend/internal/artist/errors/cannot_retrieve_artists_error.go
+++ b/backend/internal/artist/errors/cannot_retrieve_artists_error.go
@@ -4,10 +4,10 @@ type CannotRetrieveArtistsError struct {
 	message string
 }
 
-func (e *CannotRetrieveArtistsError) Error() string {
-	return e.message
-}
-
 func NewCannotRetrieveArtistsError(message string) error {
 	return &CannotRetrieveArtistsError{message: message}
+}
+
+func (e *CannotRetrieveArtistsError) Error() string {
+	return e.message
 }

--- a/backend/internal/artist/errors/no_image_found_error.go
+++ b/backend/internal/artist/errors/no_image_found_error.go
@@ -4,10 +4,10 @@ type ImageNotFoundError struct {
 	message string
 }
 
-func (e *ImageNotFoundError) Error() string {
-	return e.message
-}
-
 func NewImageNotFoundError(message string) error {
 	return &ImageNotFoundError{message: message}
+}
+
+func (e *ImageNotFoundError) Error() string {
+	return e.message
 }

--- a/backend/internal/artist/spotify/spotify_artist_deserializer.go
+++ b/backend/internal/artist/spotify/spotify_artist_deserializer.go
@@ -9,6 +9,10 @@ import (
 
 type SpotifyArtistDeserializer struct{}
 
+func NewSpotifyArtistDeserializer() SpotifyArtistDeserializer {
+	return SpotifyArtistDeserializer{}
+}
+
 func (s *SpotifyArtistDeserializer) Deserialize(setlist []byte) (*[]artist.Artist, error) {
 	var response SpotifyResponse
 	err := json.Unmarshal(setlist, &response)
@@ -26,8 +30,4 @@ func (s *SpotifyArtistDeserializer) Deserialize(setlist []byte) (*[]artist.Artis
 		result = append(result, resultArtist)
 	}
 	return &result, nil
-}
-
-func NewSpotifyArtistDeserializer() SpotifyArtistDeserializer {
-	return SpotifyArtistDeserializer{}
 }

--- a/backend/internal/artist/spotify/spotify_artist_repository.go
+++ b/backend/internal/artist/spotify/spotify_artist_repository.go
@@ -16,6 +16,16 @@ type SpotifyArtistRepository struct {
 	httpSender   httpsender.HTTPRequestSender
 }
 
+func NewSpotifyArtistRepository(accessToken string, httpSender httpsender.HTTPRequestSender) *SpotifyArtistRepository {
+	deserializer := NewSpotifyArtistDeserializer()
+	return &SpotifyArtistRepository{
+		accessToken:  accessToken,
+		host:         "api.spotify.com",
+		deserializer: &deserializer,
+		httpSender:   httpSender,
+	}
+}
+
 func (r *SpotifyArtistRepository) SetDeserializer(deserializer serialization.Deserializer[[]artist.Artist]) {
 	r.deserializer = deserializer
 }
@@ -50,14 +60,4 @@ func (r *SpotifyArtistRepository) getSearchUrl(artistName string, limit int) str
 	queryParams.Set("q", fmt.Sprintf("artist:%s", artistName))
 	queryParams.Set("limit", fmt.Sprint(limit))
 	return fmt.Sprintf("https://%s/v1/search?%s", r.host, queryParams.Encode())
-}
-
-func NewSpotifyArtistRepository(accessToken string, httpSender httpsender.HTTPRequestSender) *SpotifyArtistRepository {
-	deserializer := NewSpotifyArtistDeserializer()
-	return &SpotifyArtistRepository{
-		accessToken:  accessToken,
-		host:         "api.spotify.com",
-		deserializer: &deserializer,
-		httpSender:   httpSender,
-	}
 }

--- a/backend/internal/http/client/base_client.go
+++ b/backend/internal/http/client/base_client.go
@@ -8,10 +8,10 @@ type BaseHTTPClient struct {
 	client *http.Client
 }
 
-func (c *BaseHTTPClient) Send(request *http.Request) (*http.Response, error) {
-	return c.client.Do(request)
-}
-
 func NewBaseHTTPClient(client *http.Client) BaseHTTPClient {
 	return BaseHTTPClient{client: client}
+}
+
+func (c *BaseHTTPClient) Send(request *http.Request) (*http.Response, error) {
+	return c.client.Do(request)
 }

--- a/backend/internal/http/client/fake_client.go
+++ b/backend/internal/http/client/fake_client.go
@@ -10,6 +10,10 @@ type FakeHTTPClient struct {
 	err        error
 }
 
+func NewFakeHTTPClient() FakeHTTPClient {
+	return FakeHTTPClient{}
+}
+
 func (c *FakeHTTPClient) Send(request *http.Request) (*http.Response, error) {
 	c.requestArg = request
 
@@ -30,8 +34,4 @@ func (c *FakeHTTPClient) SetResponse(response *http.Response) {
 
 func (c *FakeHTTPClient) SetError(err error) {
 	c.err = err
-}
-
-func NewFakeHTTPClient() FakeHTTPClient {
-	return FakeHTTPClient{}
 }

--- a/backend/internal/http/sender/base_sender.go
+++ b/backend/internal/http/sender/base_sender.go
@@ -13,6 +13,10 @@ type BaseHTTPRequestSender struct {
 	client httpclient.HTTPClient
 }
 
+func NewBaseHTTPRequestSender(client httpclient.HTTPClient) BaseHTTPRequestSender {
+	return BaseHTTPRequestSender{client: client}
+}
+
 func (c *BaseHTTPRequestSender) Send(options HTTPRequestOptions) (*[]byte, error) {
 	var body io.Reader = nil
 	if options.body != nil {
@@ -47,10 +51,6 @@ func (c *BaseHTTPRequestSender) Send(options HTTPRequestOptions) (*[]byte, error
 	}
 
 	return &responseBody, nil
-}
-
-func NewBaseHTTPRequestSender(client httpclient.HTTPClient) BaseHTTPRequestSender {
-	return BaseHTTPRequestSender{client: client}
 }
 
 func addHeadersToRequest(headers map[string]string, request *http.Request) {

--- a/backend/internal/http/sender/sender.go
+++ b/backend/internal/http/sender/sender.go
@@ -19,6 +19,10 @@ type HTTPRequestOptions struct {
 	expectedStatusCode int
 }
 
+func NewHTTPRequestOptions(url string, method Method, expectedStatusCode int) HTTPRequestOptions {
+	return HTTPRequestOptions{url: url, body: nil, method: method, expectedStatusCode: expectedStatusCode}
+}
+
 func (o *HTTPRequestOptions) GetBody() []byte {
 	return o.body
 }
@@ -49,8 +53,4 @@ func (o *HTTPRequestOptions) SetBody(body []byte) {
 
 func (o *HTTPRequestOptions) SetHeaders(headers map[string]string) {
 	o.headers = headers
-}
-
-func NewHTTPRequestOptions(url string, method Method, expectedStatusCode int) HTTPRequestOptions {
-	return HTTPRequestOptions{url: url, body: nil, method: method, expectedStatusCode: expectedStatusCode}
 }

--- a/backend/internal/playlist/concurrent_playlist_service.go
+++ b/backend/internal/playlist/concurrent_playlist_service.go
@@ -18,6 +18,18 @@ type ConcurrentPlaylistService struct {
 	songRepository     song.SongRepository
 }
 
+func NewConcurrentPlaylistService(
+	playlistRepository PlaylistRepository,
+	setlistRepository setlist.SetlistRepository,
+	songRepository song.SongRepository,
+) ConcurrentPlaylistService {
+	return ConcurrentPlaylistService{
+		playlistRepository: playlistRepository,
+		setlistRepository:  setlistRepository,
+		songRepository:     songRepository,
+	}
+}
+
 func (s *ConcurrentPlaylistService) AddSetlist(playlistId string, artist string) error {
 	setlist, err := s.setlistRepository.GetSetlist(artist)
 	if err != nil {
@@ -53,16 +65,4 @@ func (s *ConcurrentPlaylistService) AddSetlist(playlistId string, artist string)
 func (s *ConcurrentPlaylistService) fetchSong(artist string, song setlist.Song, ch chan<- FetchSongResult) {
 	songDetails, err := s.songRepository.GetSong(artist, song.GetTitle())
 	ch <- FetchSongResult{Song: songDetails, Err: err}
-}
-
-func NewConcurrentPlaylistService(
-	playlistRepository PlaylistRepository,
-	setlistRepository setlist.SetlistRepository,
-	songRepository song.SongRepository,
-) ConcurrentPlaylistService {
-	return ConcurrentPlaylistService{
-		playlistRepository: playlistRepository,
-		setlistRepository:  setlistRepository,
-		songRepository:     songRepository,
-	}
 }

--- a/backend/internal/playlist/errors/cannot_add_songs_to_playlist_error.go
+++ b/backend/internal/playlist/errors/cannot_add_songs_to_playlist_error.go
@@ -4,10 +4,10 @@ type CannotAddSongsToPlaylistError struct {
 	message string
 }
 
-func (e *CannotAddSongsToPlaylistError) Error() string {
-	return e.message
-}
-
 func NewCannotAddSongsToPlaylistError(message string) error {
 	return &CannotAddSongsToPlaylistError{message: message}
+}
+
+func (e *CannotAddSongsToPlaylistError) Error() string {
+	return e.message
 }

--- a/backend/internal/playlist/errors/cannot_create_playlist_error.go
+++ b/backend/internal/playlist/errors/cannot_create_playlist_error.go
@@ -4,10 +4,10 @@ type CannotCreatePlaylistError struct {
 	message string
 }
 
-func (e *CannotCreatePlaylistError) Error() string {
-	return e.message
-}
-
 func NewCannotCreatePlaylistError(message string) error {
 	return &CannotCreatePlaylistError{message: message}
+}
+
+func (e *CannotCreatePlaylistError) Error() string {
+	return e.message
 }

--- a/backend/internal/playlist/fake_playlist_repository.go
+++ b/backend/internal/playlist/fake_playlist_repository.go
@@ -18,6 +18,10 @@ type FakePlaylistRepository struct {
 	err                error
 }
 
+func NewFakePlaylistRepository() FakePlaylistRepository {
+	return FakePlaylistRepository{}
+}
+
 func (s *FakePlaylistRepository) CreatePlaylist(userId string, playlist Playlist) error {
 	s.createPlaylistArgs = CreatePlaylistArgs{UserId: userId, Playlist: playlist}
 	return s.err
@@ -38,8 +42,4 @@ func (s *FakePlaylistRepository) GetAddSongArgs() AddSongsArgs {
 
 func (s *FakePlaylistRepository) GetCreatePlaylistSongArgs() CreatePlaylistArgs {
 	return s.createPlaylistArgs
-}
-
-func NewFakePlaylistRepository() FakePlaylistRepository {
-	return FakePlaylistRepository{}
 }

--- a/backend/internal/playlist/spotify/spotify_playlist_repository.go
+++ b/backend/internal/playlist/spotify/spotify_playlist_repository.go
@@ -18,6 +18,17 @@ type SpotifyPlaylistRepository struct {
 	httpSender         httpsender.HTTPRequestSender
 }
 
+func NewSpotifyPlaylistRepository(
+	httpSender httpsender.HTTPRequestSender, accessToken string) SpotifyPlaylistRepository {
+	return SpotifyPlaylistRepository{
+		accessToken:        accessToken,
+		host:               "api.spotify.com",
+		httpSender:         httpSender,
+		songsSerializer:    &SpotifySongsSerializer{},
+		playlistSerializer: &SpotifyPlaylistSerializer{},
+	}
+}
+
 func (r *SpotifyPlaylistRepository) AddSongs(playlistId string, songs []song.Song) error {
 	if len(songs) == 0 {
 		return errors.NewCannotAddSongsToPlaylistError("no songs provided")
@@ -86,16 +97,5 @@ func (r *SpotifyPlaylistRepository) GetSpotifyBaseHeaders() map[string]string {
 	return map[string]string{
 		"Authorization": fmt.Sprintf("Bearer %s", r.accessToken),
 		"Content-Type":  "application/json",
-	}
-}
-
-func NewSpotifyPlaylistRepository(
-	httpSender httpsender.HTTPRequestSender, accessToken string) SpotifyPlaylistRepository {
-	return SpotifyPlaylistRepository{
-		accessToken:        accessToken,
-		host:               "api.spotify.com",
-		httpSender:         httpSender,
-		songsSerializer:    &SpotifySongsSerializer{},
-		playlistSerializer: &SpotifyPlaylistSerializer{},
 	}
 }

--- a/backend/internal/serialization/errors/deserialization_error.go
+++ b/backend/internal/serialization/errors/deserialization_error.go
@@ -4,10 +4,10 @@ type DeserializationError struct {
 	message string
 }
 
-func (e *DeserializationError) Error() string {
-	return e.message
-}
-
 func NewDeserializationError(message string) error {
 	return &DeserializationError{message: message}
+}
+
+func (e *DeserializationError) Error() string {
+	return e.message
 }

--- a/backend/internal/serialization/errors/serialization_error.go
+++ b/backend/internal/serialization/errors/serialization_error.go
@@ -4,10 +4,10 @@ type SerializationError struct {
 	message string
 }
 
-func (e *SerializationError) Error() string {
-	return e.message
-}
-
 func NewSerializationError(message string) error {
 	return &SerializationError{message: message}
+}
+
+func (e *SerializationError) Error() string {
+	return e.message
 }

--- a/backend/internal/setlist/errors/cannot_retrieve_setlist_error.go
+++ b/backend/internal/setlist/errors/cannot_retrieve_setlist_error.go
@@ -4,10 +4,10 @@ type CannotRetrieveSetlistError struct {
 	message string
 }
 
-func (e *CannotRetrieveSetlistError) Error() string {
-	return e.message
-}
-
 func NewCannotRetrieveSetlistError(message string) error {
 	return &CannotRetrieveSetlistError{message: message}
+}
+
+func (e *CannotRetrieveSetlistError) Error() string {
+	return e.message
 }

--- a/backend/internal/setlist/fake_setlist_repository.go
+++ b/backend/internal/setlist/fake_setlist_repository.go
@@ -6,6 +6,10 @@ type FakeSetlistRepository struct {
 	err         error
 }
 
+func NewFakeSetlistRepository() FakeSetlistRepository {
+	return FakeSetlistRepository{}
+}
+
 func (s *FakeSetlistRepository) GetSetlist(artist string) (*Setlist, error) {
 	s.artist = artist
 	return s.returnValue, s.err
@@ -21,8 +25,4 @@ func (s *FakeSetlistRepository) SetReturnValue(setlist *Setlist) {
 
 func (s *FakeSetlistRepository) SetError(err error) {
 	s.err = err
-}
-
-func NewFakeSetlistRepository() FakeSetlistRepository {
-	return FakeSetlistRepository{}
 }

--- a/backend/internal/setlist/setlist.go
+++ b/backend/internal/setlist/setlist.go
@@ -5,14 +5,14 @@ type Setlist struct {
 	songs  []Song
 }
 
+func NewSetlist(artist string, songs []Song) Setlist {
+	return Setlist{artist: artist, songs: songs}
+}
+
 func (s Setlist) GetArtist() string {
 	return s.artist
 }
 
 func (s Setlist) GetSongs() []Song {
 	return s.songs
-}
-
-func NewSetlist(artist string, songs []Song) Setlist {
-	return Setlist{artist: artist, songs: songs}
 }

--- a/backend/internal/setlist/setlist_song.go
+++ b/backend/internal/setlist/setlist_song.go
@@ -4,10 +4,10 @@ type Song struct {
 	title string
 }
 
-func (s Song) GetTitle() string {
-	return s.title
-}
-
 func NewSong(title string) Song {
 	return Song{title: title}
+}
+
+func (s Song) GetTitle() string {
+	return s.title
 }

--- a/backend/internal/setlist/setlistfm/setlistfm_deserializer.go
+++ b/backend/internal/setlist/setlistfm/setlistfm_deserializer.go
@@ -10,6 +10,10 @@ type SetlistFMDeserializer struct {
 	minimumSongs int
 }
 
+func NewSetlistFMDeserializer() SetlistFMDeserializer {
+	return SetlistFMDeserializer{minimumSongs: 1}
+}
+
 func (s *SetlistFMDeserializer) SetMinimumSongs(minimumSongs int) {
 	s.minimumSongs = minimumSongs
 }
@@ -35,8 +39,4 @@ func (s *SetlistFMDeserializer) findSetlistWithMinSongs(response SetlistFMRespon
 	}
 
 	return result
-}
-
-func NewSetlistFMDeserializer() SetlistFMDeserializer {
-	return SetlistFMDeserializer{minimumSongs: 1}
 }

--- a/backend/internal/setlist/setlistfm/setlistfm_setlist_repository.go
+++ b/backend/internal/setlist/setlistfm/setlistfm_setlist_repository.go
@@ -17,6 +17,16 @@ type SetlistFMRepository struct {
 	httpSender   httpsender.HTTPRequestSender
 }
 
+func NewSetlistFMSetlistRepository(apiKey string, httpSender httpsender.HTTPRequestSender) *SetlistFMRepository {
+	deserializer := NewSetlistFMDeserializer()
+	return &SetlistFMRepository{
+		host:         "api.setlist.fm",
+		apiKey:       apiKey,
+		deserializer: &deserializer,
+		httpSender:   httpSender,
+	}
+}
+
 func (r *SetlistFMRepository) SetDeserializer(deserializer serialization.Deserializer[setlist.Setlist]) {
 	r.deserializer = deserializer
 }
@@ -60,14 +70,4 @@ func (r *SetlistFMRepository) getSetlistFullUrl(artist string) string {
 	queryParams.Set("artistName", artist)
 	setlistPath := "rest/1.0/search/setlists"
 	return fmt.Sprintf("https://%s/%s?%s", r.host, setlistPath, queryParams.Encode())
-}
-
-func NewSetlistFMSetlistRepository(apiKey string, httpSender httpsender.HTTPRequestSender) *SetlistFMRepository {
-	deserializer := NewSetlistFMDeserializer()
-	return &SetlistFMRepository{
-		host:         "api.setlist.fm",
-		apiKey:       apiKey,
-		deserializer: &deserializer,
-		httpSender:   httpSender,
-	}
 }

--- a/backend/internal/song/errors/cannot_retrieve_song_error.go
+++ b/backend/internal/song/errors/cannot_retrieve_song_error.go
@@ -4,10 +4,10 @@ type CannotRetrieveSongError struct {
 	message string
 }
 
-func (e *CannotRetrieveSongError) Error() string {
-	return e.message
-}
-
 func NewCannotRetrieveSongError(message string) error {
 	return &CannotRetrieveSongError{message: message}
+}
+
+func (e *CannotRetrieveSongError) Error() string {
+	return e.message
 }

--- a/backend/internal/song/fake_song_repository.go
+++ b/backend/internal/song/fake_song_repository.go
@@ -16,6 +16,12 @@ type FakeSongRepository struct {
 	repository *WrappedFakeSongRepository
 }
 
+func NewFakeSongRepository() FakeSongRepository {
+	return FakeSongRepository{
+		repository: &WrappedFakeSongRepository{getSongArgs: []GetSongArgs{}, songs: []interface{}{}},
+	}
+}
+
 func (r *FakeSongRepository) GetSong(artist string, title string) (*Song, error) {
 	return r.repository.GetSong(artist, title)
 }
@@ -26,12 +32,6 @@ func (r *FakeSongRepository) GetGetSongArgs() []GetSongArgs {
 
 func (r *FakeSongRepository) SetSongs(songs []interface{}) {
 	r.repository.songs = songs
-}
-
-func NewFakeSongRepository() FakeSongRepository {
-	return FakeSongRepository{
-		repository: &WrappedFakeSongRepository{getSongArgs: []GetSongArgs{}, songs: []interface{}{}},
-	}
 }
 
 type WrappedFakeSongRepository struct {

--- a/backend/internal/song/song.go
+++ b/backend/internal/song/song.go
@@ -4,10 +4,10 @@ type Song struct {
 	uri string
 }
 
-func (s *Song) GetUri() string {
-	return s.uri
-}
-
 func NewSong(uri string) Song {
 	return Song{uri: uri}
+}
+
+func (s *Song) GetUri() string {
+	return s.uri
 }

--- a/backend/internal/song/spotify/spotify_song_repository.go
+++ b/backend/internal/song/spotify/spotify_song_repository.go
@@ -17,6 +17,14 @@ type SpotifySongRepository struct {
 	deserializer serialization.Deserializer[[]song.Song]
 }
 
+func NewSpotifySongRepository(
+	accessToken string,
+	httpSender httpsender.HTTPRequestSender,
+) *SpotifySongRepository {
+	return &SpotifySongRepository{
+		accessToken: accessToken, host: "api.spotify.com", httpSender: httpSender, deserializer: &SpotifySongsDeserializer{}}
+}
+
 func (r *SpotifySongRepository) GetSong(artist string, title string) (*song.Song, error) {
 	httpOptions := r.createSongHttpOptions(artist, title)
 	responseBody, err := r.httpSender.Send(httpOptions)
@@ -58,12 +66,4 @@ func (r *SpotifySongRepository) getSetlistFullUrl(artist string, title string) s
 	queryParams.Set("type", "track")
 	setlistPath := "v1/search"
 	return fmt.Sprintf("https://%s/%s?%s", r.host, setlistPath, queryParams.Encode())
-}
-
-func NewSpotifySongRepository(
-	accessToken string,
-	httpSender httpsender.HTTPRequestSender,
-) *SpotifySongRepository {
-	return &SpotifySongRepository{
-		accessToken: accessToken, host: "api.spotify.com", httpSender: httpSender, deserializer: &SpotifySongsDeserializer{}}
 }

--- a/backend/internal/song/spotify/spotify_songs_deserializer.go
+++ b/backend/internal/song/spotify/spotify_songs_deserializer.go
@@ -9,6 +9,10 @@ import (
 
 type SpotifySongsDeserializer struct{}
 
+func NewSpotifySongsDeserializer() SpotifySongsDeserializer {
+	return SpotifySongsDeserializer{}
+}
+
 func (s *SpotifySongsDeserializer) Deserialize(setlist []byte) (*[]song.Song, error) {
 	var response SpotifyResponse
 	err := json.Unmarshal(setlist, &response)
@@ -21,8 +25,4 @@ func (s *SpotifySongsDeserializer) Deserialize(setlist []byte) (*[]song.Song, er
 		result = append(result, song.NewSong(currentSong.Uri))
 	}
 	return &result, nil
-}
-
-func NewSpotifySongsDeserializer() SpotifySongsDeserializer {
-	return SpotifySongsDeserializer{}
 }

--- a/backend/internal/testtools/io.go
+++ b/backend/internal/testtools/io.go
@@ -30,14 +30,14 @@ func GetParentDir(t *testing.T) string {
 
 type ErrorReader struct{}
 
+func NewErrorReader() ErrorReader {
+	return ErrorReader{}
+}
+
 func (ErrorReader) Read(p []byte) (n int, err error) {
 	return 0, errors.New("test error")
 }
 
 func (ErrorReader) Close() error {
 	return nil
-}
-
-func NewErrorReader() ErrorReader {
-	return ErrorReader{}
 }


### PR DESCRIPTION
# Description

I have not found any Golang standard for this, but I find convenient to have constructors at top, so they are more accessible when reading the code.