### PR TITLE
feat: FW-19 Implement auth token parse middleware

### DIFF
--- a/backend/cmd/middleware/auth_token.go
+++ b/backend/cmd/middleware/auth_token.go
@@ -1,0 +1,35 @@
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	types "festwrap/internal"
+)
+
+// Extracts the Bearer Auth token in the header and stores in the context variable with the given key
+type AuthTokenMiddleware struct {
+	tokenKey types.ContextKey
+	handler  http.Handler
+}
+
+func NewAuthTokenMiddleware(tokenKey types.ContextKey, handler http.Handler) AuthTokenMiddleware {
+	return AuthTokenMiddleware{tokenKey: tokenKey, handler: handler}
+}
+
+func (m AuthTokenMiddleware) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	authHeader := r.Header.Get("Authorization")
+	if authHeader == "" {
+		http.Error(w, "Missing authorization header", http.StatusBadRequest)
+		return
+	} else if !strings.HasPrefix(authHeader, "Bearer ") {
+		http.Error(w, "Unexpected authorization header format", http.StatusUnprocessableEntity)
+		return
+	}
+
+	token := strings.TrimPrefix(authHeader, "Bearer ")
+	ctxWithToken := context.WithValue(r.Context(), m.tokenKey, token)
+	requestWithToken := r.WithContext(ctxWithToken)
+	m.handler.ServeHTTP(w, requestWithToken)
+}

--- a/backend/cmd/middleware/auth_token_test.go
+++ b/backend/cmd/middleware/auth_token_test.go
@@ -1,0 +1,66 @@
+package middleware
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	types "festwrap/internal"
+	"festwrap/internal/testtools"
+)
+
+type GetTokenHandler struct{}
+
+func (h GetTokenHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	token, _ := r.Context().Value(defaultTokenKey()).(string)
+	w.WriteHeader(http.StatusAccepted)
+	fmt.Fprint(w, token)
+}
+
+func defaultTokenKey() types.ContextKey {
+	var tokenKey types.ContextKey = "token"
+	return tokenKey
+}
+
+func testSetup() (AuthTokenMiddleware, *http.Request, *httptest.ResponseRecorder) {
+	middleware := NewAuthTokenMiddleware(defaultTokenKey(), GetTokenHandler{})
+	request := httptest.NewRequest("GET", "http://example.com", nil)
+	writer := httptest.NewRecorder()
+	return middleware, request, writer
+}
+
+func TestBadRequestErrorOnMissingAuthHeader(t *testing.T) {
+	middleware, request, writer := testSetup()
+
+	middleware.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Code, http.StatusBadRequest)
+}
+
+func TestUnprocessableEntityErrorOnWronglyFormattedAuthHeader(t *testing.T) {
+	middleware, request, writer := testSetup()
+	request.Header.Set("Authorization", "something")
+
+	middleware.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Code, http.StatusUnprocessableEntity)
+}
+
+func TestTokenIsPlacedInExpectedContextKey(t *testing.T) {
+	middleware, request, writer := testSetup()
+	request.Header.Set("Authorization", "Bearer 1234")
+
+	middleware.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Body.String(), "1234")
+}
+
+func TestMiddlewareReturnsStatusCodeofTheHandler(t *testing.T) {
+	middleware, request, writer := testSetup()
+	request.Header.Set("Authorization", "Bearer 1234")
+
+	middleware.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Code, http.StatusAccepted)
+}

--- a/backend/internal/types.go
+++ b/backend/internal/types.go
@@ -1,0 +1,3 @@
+package types
+
+type ContextKey string


### PR DESCRIPTION
# Description

Adds a middleware that reads the bearer token and adds it to the request context. We will use this middleware for all endpoints we are going to implement, as they will require a bearer token for authenticating with the Spotify API.