### PR TITLE
feat: FW-19 Implement search artist handler

### DIFF
--- a/backend/cmd/artist/search_artist.go
+++ b/backend/cmd/artist/search_artist.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"net/http"
 	"os"
 
+	types "festwrap/internal"
 	spotifyArtist "festwrap/internal/artist/spotify"
 	httpclient "festwrap/internal/http/client"
 	httpsender "festwrap/internal/http/sender"
@@ -23,17 +25,18 @@ func main() {
 
 	fmt.Printf("Searching for artist %s into Spotify API, retrieving %d results at most\n", *artist, *limit)
 
-	artistRepository := spotifyArtist.NewSpotifyArtistRepository(
-		*spotifyAccessToken,
-		&httpSender,
-	)
+	tokenKey := types.ContextKey("myToken")
+	artistRepository := spotifyArtist.NewSpotifyArtistRepository(&httpSender)
+	artistRepository.SetTokenKey(tokenKey)
 
-	artists, err := artistRepository.SearchArtist(*artist, *limit)
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, tokenKey, *spotifyAccessToken)
+	artists, err := artistRepository.SearchArtist(ctx, *artist, *limit)
 	if err != nil {
 		message := fmt.Sprintf("Error searching artist: %v", err)
 		fmt.Println(message)
 		os.Exit(1)
 	}
 
-	fmt.Printf("Found %v\n", *artists)
+	fmt.Printf("Found %v\n", artists)
 }

--- a/backend/cmd/handler/artists.go
+++ b/backend/cmd/handler/artists.go
@@ -1,0 +1,93 @@
+package handler
+
+import (
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"festwrap/internal/artist"
+	"festwrap/internal/serialization"
+)
+
+type SearchArtistHandler struct {
+	encoder      serialization.Encoder[[]artist.Artist]
+	defaultLimit int
+	maxLimit     int
+	repository   artist.ArtistRepository
+}
+
+func NewSearchArtistHandler(repository artist.ArtistRepository) SearchArtistHandler {
+	return SearchArtistHandler{
+		encoder:      serialization.NewJsonEncoder[[]artist.Artist](),
+		repository:   repository,
+		maxLimit:     10,
+		defaultLimit: 5,
+	}
+}
+
+func (h *SearchArtistHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	name := r.URL.Query().Get("name")
+	if name == "" {
+		http.Error(w, "Validation error: artist name must be provided", http.StatusBadRequest)
+		return
+	}
+
+	limit, err := h.readLimit(r)
+	if err != nil {
+		http.Error(
+			w,
+			fmt.Sprintf("Validation error: %v", err.Error()),
+			http.StatusUnprocessableEntity,
+		)
+		return
+	}
+
+	artists, err := h.repository.SearchArtist(r.Context(), name, limit)
+	if err != nil {
+		h.writeUnexpectedError(w)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	err = h.encoder.Encode(w, artists)
+	if err != nil {
+		h.writeUnexpectedError(w)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}
+
+func (h *SearchArtistHandler) readLimit(r *http.Request) (int, error) {
+	limitStr := r.URL.Query().Get("limit")
+	if limitStr == "" {
+		return h.defaultLimit, nil
+	}
+
+	limit, err := strconv.Atoi(limitStr)
+	if err != nil {
+		return 0, fmt.Errorf("limit must be an integer, found %s", limitStr)
+	}
+
+	if limit < 1 || limit > h.maxLimit {
+		return 0, fmt.Errorf("limit must be in interval [1, %d]", h.maxLimit)
+	}
+
+	return limit, nil
+}
+
+func (h *SearchArtistHandler) writeUnexpectedError(w http.ResponseWriter) {
+	http.Error(w, "Unexpected error: could not perform artist search", http.StatusInternalServerError)
+}
+
+func (h *SearchArtistHandler) SetEncoder(encoder serialization.Encoder[[]artist.Artist]) {
+	h.encoder = encoder
+}
+
+func (h *SearchArtistHandler) SetMaxLimit(limit int) {
+	h.maxLimit = limit
+}
+
+func (h *SearchArtistHandler) SetDefaultLimit(limit int) {
+	h.defaultLimit = limit
+}

--- a/backend/cmd/handler/artists_test.go
+++ b/backend/cmd/handler/artists_test.go
@@ -1,0 +1,156 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"festwrap/internal/artist"
+	"festwrap/internal/serialization"
+	"festwrap/internal/testtools"
+)
+
+func defaultArtists() []artist.Artist {
+	return []artist.Artist{
+		artist.NewArtist("Brutus"),
+		artist.NewArtistWithImageUri("Boysetsfire", "http://some/image.jpg"),
+	}
+}
+
+func defaultQueryParams() map[string]string {
+	return map[string]string{
+		"name":  "Brutus",
+		"limit": "8",
+	}
+}
+
+func buildRequestWithParams(t *testing.T, params map[string]string) *http.Request {
+	t.Helper()
+	requestUrl, err := url.Parse("https://example.com/api")
+	if err != nil {
+		t.Errorf("Could not create request: %v", err.Error())
+	}
+
+	queryParams := requestUrl.Query()
+	for name, value := range params {
+		queryParams.Add(name, value)
+	}
+
+	requestUrl.RawQuery = queryParams.Encode()
+	return httptest.NewRequest("GET", requestUrl.String(), nil)
+}
+
+func createSearchArtistHandler() SearchArtistHandler {
+	repository := artist.FakeArtistRepository{}
+	repository.SetSearchReturnValue(defaultArtists())
+	return NewSearchArtistHandler(&repository)
+}
+
+func unmarshalSearchArtistResponse(t *testing.T, bytes []byte) []artist.Artist {
+	t.Helper()
+	var response []artist.Artist
+	err := json.Unmarshal(bytes, &response)
+	if err != nil {
+		t.Errorf("Error unmarshalling body: %v", err)
+	}
+	return response
+}
+
+func setup(t *testing.T, params map[string]string) (*httptest.ResponseRecorder, *http.Request, SearchArtistHandler) {
+	t.Helper()
+	handler := createSearchArtistHandler()
+	writer := httptest.NewRecorder()
+	request := buildRequestWithParams(t, params)
+	return writer, request, handler
+}
+
+func TestBadRequestIfNameNotProvided(t *testing.T) {
+	params := defaultQueryParams()
+	delete(params, "name")
+	writer, request, handler := setup(t, params)
+
+	handler.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Code, http.StatusBadRequest)
+}
+
+func TestLimitStatusCodeDependingOnValue(t *testing.T) {
+	tests := map[string]struct {
+		limit    string
+		maxLimit int
+		status   int
+	}{
+		"below one": {
+			limit:    "0",
+			maxLimit: 5,
+			status:   http.StatusUnprocessableEntity,
+		},
+		"above max": {
+			limit:    "6",
+			maxLimit: 5,
+			status:   http.StatusUnprocessableEntity,
+		},
+		"not an integer": {
+			limit:    "something",
+			maxLimit: 5,
+			status:   http.StatusUnprocessableEntity,
+		},
+		"within limits": {
+			limit:    "3",
+			maxLimit: 5,
+			status:   http.StatusOK,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			params := defaultQueryParams()
+			params["limit"] = test.limit
+			writer, request, handler := setup(t, params)
+			handler.SetMaxLimit(test.maxLimit)
+
+			handler.ServeHTTP(writer, request)
+
+			testtools.AssertEqual(t, writer.Code, test.status)
+		})
+	}
+}
+
+func TestSearchArtistRepositoryCalledWithParams(t *testing.T) {
+	repository := artist.FakeArtistRepository{}
+	repository.SetSearchReturnValue(defaultArtists())
+	handler := NewSearchArtistHandler(&repository)
+	request := buildRequestWithParams(t, defaultQueryParams())
+
+	handler.ServeHTTP(httptest.NewRecorder(), request)
+
+	actual := repository.GetSearchArtistArgs()
+	testtools.AssertEqual(t, actual.Context, request.Context())
+	testtools.AssertEqual(t, fmt.Sprint(actual.Limit), defaultQueryParams()["limit"])
+	testtools.AssertEqual(t, actual.Name, defaultQueryParams()["name"])
+}
+
+func TestSearchArtistReturnsArtists(t *testing.T) {
+	writer, request, handler := setup(t, defaultQueryParams())
+
+	handler.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Code, http.StatusOK)
+	testtools.AssertEqual(t, unmarshalSearchArtistResponse(t, writer.Body.Bytes()), defaultArtists())
+}
+
+func TestSearchArtistReturnsInternalErrorOnEncoderError(t *testing.T) {
+	encoder := serialization.FakeEncoder[[]artist.Artist]{}
+	encoder.SetError(errors.New("test error"))
+	writer, request, handler := setup(t, defaultQueryParams())
+	handler.SetEncoder(encoder)
+
+	handler.ServeHTTP(writer, request)
+
+	testtools.AssertEqual(t, writer.Code, http.StatusInternalServerError)
+}

--- a/backend/internal/artist/artist.go
+++ b/backend/internal/artist/artist.go
@@ -1,18 +1,18 @@
 package artist
 
 type Artist struct {
-	name     string
-	imageUri string
+	Name     string `json:"name"`
+	ImageUri string `json:"imageUri,omitempty"`
 }
 
 func NewArtist(name string) Artist {
-	return Artist{name: name}
+	return Artist{Name: name}
 }
 
 func NewArtistWithImageUri(name string, imageUri string) Artist {
-	return Artist{name: name, imageUri: imageUri}
+	return Artist{Name: name, ImageUri: imageUri}
 }
 
 func (a *Artist) SetImageUri(imageUri string) {
-	a.imageUri = imageUri
+	a.ImageUri = imageUri
 }

--- a/backend/internal/artist/artist_repository.go
+++ b/backend/internal/artist/artist_repository.go
@@ -1,5 +1,7 @@
 package artist
 
+import "context"
+
 type ArtistRepository interface {
-	SearchArtist(name string, limit int) (*[]Artist, error)
+	SearchArtist(ctx context.Context, name string, limit int) ([]Artist, error)
 }

--- a/backend/internal/artist/fake_artist_repository.go
+++ b/backend/internal/artist/fake_artist_repository.go
@@ -1,0 +1,36 @@
+package artist
+
+import "context"
+
+type SearchArtistArgs struct {
+	Context context.Context
+	Name    string
+	Limit   int
+}
+
+type SearchArtistReturn struct {
+	value []Artist
+	err   error
+}
+
+type FakeArtistRepository struct {
+	searchArgs   SearchArtistArgs
+	searchReturn SearchArtistReturn
+}
+
+func (r *FakeArtistRepository) SearchArtist(ctx context.Context, name string, limit int) ([]Artist, error) {
+	r.searchArgs = SearchArtistArgs{Name: name, Limit: limit, Context: ctx}
+	return r.searchReturn.value, r.searchReturn.err
+}
+
+func (r *FakeArtistRepository) GetSearchArtistArgs() SearchArtistArgs {
+	return r.searchArgs
+}
+
+func (r *FakeArtistRepository) SetSearchReturnValue(value []Artist) {
+	r.searchReturn.value = value
+}
+
+func (r *FakeArtistRepository) SetSearchArtistError(err error) {
+	r.searchReturn.err = err
+}

--- a/backend/internal/serialization/encoder.go
+++ b/backend/internal/serialization/encoder.go
@@ -1,0 +1,20 @@
+package serialization
+
+import (
+	"encoding/json"
+	"io"
+)
+
+type Encoder[T any] interface {
+	Encode(w io.Writer, object T) error
+}
+
+type JsonEncoder[T any] struct{}
+
+func NewJsonEncoder[T any]() JsonEncoder[T] {
+	return JsonEncoder[T]{}
+}
+
+func (e JsonEncoder[T]) Encode(w io.Writer, object T) error {
+	return json.NewEncoder(w).Encode(object)
+}

--- a/backend/internal/serialization/fake_encoder.go
+++ b/backend/internal/serialization/fake_encoder.go
@@ -1,0 +1,27 @@
+package serialization
+
+import (
+	"io"
+)
+
+type EncodeArgs[T any] struct {
+	Writer io.Writer
+	Object T
+}
+
+type FakeEncoder[T any] struct {
+	encodeArgs EncodeArgs[T]
+	err        error
+}
+
+func (e FakeEncoder[T]) GetEncodeArgs() EncodeArgs[T] {
+	return e.encodeArgs
+}
+
+func (e *FakeEncoder[T]) SetError(err error) {
+	e.err = err
+}
+
+func (e FakeEncoder[T]) Encode(w io.Writer, object T) error {
+	return e.err
+}


### PR DESCRIPTION
# Description

Implements handler to retrieve artists by name. It required implementing a couple of extra classes (i.e. fake repository, encoders) and modifying the repository interface to include the context. By adding the access token in the context, we do not need to couple the repository interface to the specific Spotify bearer authorization.